### PR TITLE
Fix rollup copy_to_bin_actions use

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,6 +72,9 @@ jobs:
                     # Don't test bzlmod with Bazel 5 (not supported)
                     - bazelversion: 5.3.2
                       bzlmodEnabled: true
+                    # Broken as Bazel 5 doesn't have @local_config_platform//:constraints.bzl
+                    - bazelversion: 5.3.2
+                      folder: .
 
         # Steps represent a sequence of tasks that will be executed as part of the job
         steps:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,12 +9,13 @@ module(
 # Lower-bound (minimum) versions of direct dependencies
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 
-# Need #397 to skip stardoc targets
-bazel_dep(name = "aspect_bazel_lib", version = "1.30.2")
+# Need feat: backport 2.x features for interoperability by @kormide in #657
+bazel_dep(name = "aspect_bazel_lib", version = "1.38.0")
 
 # 1.19.0: Need attribute 'dev' in 'npm_package_store_internal' rule
 # 1.29.2: Need Windows fix to disable fs patches
-bazel_dep(name = "aspect_rules_js", version = "1.29.2")
+# 1.31.1: fix: allow for Bazel 7 flag rename (#1178)
+bazel_dep(name = "aspect_rules_js", version = "1.31.0")
 bazel_dep(name = "rules_nodejs", version = "5.5.3")
 bazel_dep(name = "platforms", version = "0.0.5")
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,16 +7,16 @@ module(
 )
 
 # Lower-bound (minimum) versions of direct dependencies
-bazel_dep(name = "bazel_skylib", version = "1.5.0")
+bazel_dep(name = "bazel_skylib", version = "1.3.0")
 
-# Needs 2.x for coreutils toolchain resolution
-bazel_dep(name = "aspect_bazel_lib", version = "2.2.0")
+# Need #397 to skip stardoc targets
+bazel_dep(name = "aspect_bazel_lib", version = "1.30.2")
 
 # 1.19.0: Need attribute 'dev' in 'npm_package_store_internal' rule
 # 1.29.2: Need Windows fix to disable fs patches
-bazel_dep(name = "aspect_rules_js", version = "1.35.0")
-bazel_dep(name = "rules_nodejs", version = "5.8.2")
-bazel_dep(name = "platforms", version = "0.0.7")
+bazel_dep(name = "aspect_rules_js", version = "1.29.2")
+bazel_dep(name = "rules_nodejs", version = "5.5.3")
+bazel_dep(name = "platforms", version = "0.0.5")
 
 rollup = use_extension("@aspect_rules_rollup//rollup:extensions.bzl", "rollup")
 rollup.toolchain(
@@ -24,21 +24,3 @@ rollup.toolchain(
     rollup_version = "v2.70.2",
 )
 use_repo(rollup, "rollup")
-
-npm = use_extension(
-    "@aspect_rules_js//npm:extensions.bzl",
-    "npm",
-)
-
-npm.npm_translate_lock(
-    name = "npm",
-    npmrc = "//:.npmrc",
-    pnpm_lock = "//:pnpm-lock.yaml",
-)
-
-use_repo(npm, "npm")
-
-bazel_dep(name = "buildifier_prebuilt", version = "6.0.0.1", dev_dependency = True)
-bazel_dep(name = "gazelle", version = "0.35.0", repo_name = "bazel_gazelle", dev_dependency = True)
-bazel_dep(name = "rules_go", version = "0.44.1", repo_name = "io_bazel_rules_go", dev_dependency = True)
-bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.5.0", dev_dependency = True)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,16 +7,16 @@ module(
 )
 
 # Lower-bound (minimum) versions of direct dependencies
-bazel_dep(name = "bazel_skylib", version = "1.3.0")
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
 
-# Need #397 to skip stardoc targets
-bazel_dep(name = "aspect_bazel_lib", version = "1.30.2")
+# Needs 2.x for coreutils toolchain resolution
+bazel_dep(name = "aspect_bazel_lib", version = "2.2.0")
 
 # 1.19.0: Need attribute 'dev' in 'npm_package_store_internal' rule
 # 1.29.2: Need Windows fix to disable fs patches
-bazel_dep(name = "aspect_rules_js", version = "1.29.2")
-bazel_dep(name = "rules_nodejs", version = "5.5.3")
-bazel_dep(name = "platforms", version = "0.0.5")
+bazel_dep(name = "aspect_rules_js", version = "1.35.0")
+bazel_dep(name = "rules_nodejs", version = "5.8.2")
+bazel_dep(name = "platforms", version = "0.0.7")
 
 rollup = use_extension("@aspect_rules_rollup//rollup:extensions.bzl", "rollup")
 rollup.toolchain(
@@ -24,3 +24,21 @@ rollup.toolchain(
     rollup_version = "v2.70.2",
 )
 use_repo(rollup, "rollup")
+
+npm = use_extension(
+    "@aspect_rules_js//npm:extensions.bzl",
+    "npm",
+)
+
+npm.npm_translate_lock(
+    name = "npm",
+    npmrc = "//:.npmrc",
+    pnpm_lock = "//:pnpm-lock.yaml",
+)
+
+use_repo(npm, "npm")
+
+bazel_dep(name = "buildifier_prebuilt", version = "6.0.0.1", dev_dependency = True)
+bazel_dep(name = "gazelle", version = "0.35.0", repo_name = "bazel_gazelle", dev_dependency = True)
+bazel_dep(name = "rules_go", version = "0.44.1", repo_name = "io_bazel_rules_go", dev_dependency = True)
+bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.5.0", dev_dependency = True)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,6 +11,10 @@ load("//rollup:dependencies.bzl", "rules_rollup_dependencies")
 # Fetch dependencies which users need as well
 rules_rollup_dependencies()
 
+load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
+
+rules_js_dependencies()
+
 load("@rules_nodejs//nodejs:repositories.bzl", "nodejs_register_toolchains")
 
 nodejs_register_toolchains(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,7 +33,7 @@ npm_repositories()
 
 load("@aspect_bazel_lib//lib:repositories.bzl", "DEFAULT_YQ_VERSION", "aspect_bazel_lib_dependencies", "register_yq_toolchains")
 
-aspect_bazel_lib_dependencies(override_local_config_platform = True)
+aspect_bazel_lib_dependencies()
 
 register_yq_toolchains(
     version = DEFAULT_YQ_VERSION,

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -1,8 +1,9 @@
 "Bazel dependencies"
 
 bazel_dep(name = "aspect_rules_rollup", version = "0.0.0", dev_dependency = True)
+bazel_dep(name = "aspect_bazel_lib", version = "2.2.0", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.3.0", dev_dependency = True)
-bazel_dep(name = "aspect_rules_js", version = "1.29.2", dev_dependency = True)
+bazel_dep(name = "aspect_rules_js", version = "1.35.0", dev_dependency = True)
 
 local_path_override(
     module_name = "aspect_rules_rollup",

--- a/e2e/smoke/WORKSPACE.bazel
+++ b/e2e/smoke/WORKSPACE.bazel
@@ -18,6 +18,10 @@ load("@aspect_rules_rollup//rollup:dependencies.bzl", "rules_rollup_dependencies
 # already fetched all the dependencies.
 rules_rollup_dependencies()
 
+load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
+
+rules_js_dependencies()
+
 # Fetch and register a node toolchain, if you haven't already
 load("@rules_nodejs//nodejs:repositories.bzl", "DEFAULT_NODE_VERSION", "nodejs_register_toolchains")
 

--- a/rollup/defs.bzl
+++ b/rollup/defs.bzl
@@ -1,5 +1,6 @@
 "wrapper macro for rollup rule"
 
+load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS")
 load("@aspect_bazel_lib//lib:directory_path.bzl", "directory_path")
 load("@aspect_rules_js//js:defs.bzl", "js_binary")
 load("//rollup/private:rollup.bzl", rollup_lib = "lib")
@@ -8,6 +9,7 @@ _rollup = rule(
     implementation = rollup_lib.implementation,
     attrs = rollup_lib.attrs,
     outputs = rollup_lib.outputs,
+    toolchains = COPY_FILE_TO_BIN_TOOLCHAINS,
 )
 
 def rollup(

--- a/rollup/dependencies.bzl
+++ b/rollup/dependencies.bzl
@@ -11,16 +11,16 @@ def rules_rollup_dependencies():
 
     http_archive(
         name = "aspect_bazel_lib",
-        sha256 = "97fa63d95cc9af006c4c7b2123ddd2a91fb8d273012f17648e6423bae2c69470",
-        strip_prefix = "bazel-lib-1.30.2",
-        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.30.2/bazel-lib-v1.30.2.tar.gz",
+        sha256 = "b848cd8e93be7f18c3deda6d2f3ade92a657d3585e119953bc50dc75fef535c2",
+        strip_prefix = "bazel-lib-1.38.0",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.38.0/bazel-lib-v1.38.0.tar.gz",
     )
 
     http_archive(
         name = "aspect_rules_js",
-        sha256 = "7cb2d84b7d5220194627c9a0267ae599e357350e75ea4f28f337a25ca6219b83",
-        strip_prefix = "rules_js-1.29.2",
-        url = "https://github.com/aspect-build/rules_js/releases/download/v1.29.2/rules_js-v1.29.2.tar.gz",
+        sha256 = "7b2a4d1d264e105eae49a27e2e78065b23e2e45724df2251eacdd317e95bfdfd",
+        strip_prefix = "rules_js-1.31.0",
+        url = "https://github.com/aspect-build/rules_js/releases/download/v1.31.0/rules_js-v1.31.0.tar.gz",
     )
 
     http_archive(

--- a/rollup/private/rollup.bzl
+++ b/rollup/private/rollup.bzl
@@ -1,6 +1,6 @@
 "rollup"
 
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_file_to_bin_action", "copy_files_to_bin_actions", "COPY_FILE_TO_BIN_TOOLCHAINS")
+load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS", "copy_file_to_bin_action", "copy_files_to_bin_actions")
 load("@aspect_rules_js//js:libs.bzl", "js_lib_helpers")
 load("@aspect_rules_js//js:providers.bzl", "JsInfo", "js_info")
 

--- a/rollup/private/rollup.bzl
+++ b/rollup/private/rollup.bzl
@@ -1,6 +1,6 @@
 "rollup"
 
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_file_to_bin_action", "copy_files_to_bin_actions")
+load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_file_to_bin_action", "copy_files_to_bin_actions", "COPY_FILE_TO_BIN_TOOLCHAINS")
 load("@aspect_rules_js//js:libs.bzl", "js_lib_helpers")
 load("@aspect_rules_js//js:providers.bzl", "JsInfo", "js_info")
 
@@ -242,4 +242,5 @@ rollup = rule(
     implementation = lib.implementation,
     attrs = lib.attrs,
     outputs = lib.outputs,
+    toolchains = COPY_FILE_TO_BIN_TOOLCHAINS,
 )


### PR DESCRIPTION
fixes https://github.com/aspect-build/rules_rollup/issues/89

Consumers of `rules_rollup` using newer versions of `aspect-build/bazel-lib` were experiencing an error where `_rollup` was not providing the required `toolchains` rule attr to successfully call `copy_to_bin_action`.

Fixed it.
